### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,8 @@ quickroute-gps (2.4-16) UNRELEASED; urgency=medium
   * Set debhelper-compat version in Build-Depends.
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
   * Fix day-of-week for changelog entry 2.4-2.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on devscripts, tzdata and xauth.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 05:52:02 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Kristof Ralovich <ralovich@in.tum.de>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.8
-Build-Depends: debhelper-compat (= 12), mono-xbuild (>= 2.6.7), devscripts (>= 2.11), cli-common-dev (>= 0.8), mono-mcs (>= 2.8), liblog4net1.2-cil (>= 1.2.10), xvfb (>= 1.12.4), xauth (>= 1.0.4), tzdata (>= 2016f)
+Build-Depends: debhelper-compat (= 12), mono-xbuild (>= 2.6.7), devscripts, cli-common-dev (>= 0.8), mono-mcs (>= 2.8), liblog4net1.2-cil (>= 1.2.10), xvfb (>= 1.12.4), xauth, tzdata
 Homepage: https://github.com/ralovich/quickroute-linux
 Vcs-Git: https://github.com/ralovich/quickroute-linux.git
 Vcs-Browser: https://github.com/ralovich/quickroute-linux.git


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/quickroute-gps/0512a2d7-cabc-4b00-b8fc-7366eb55bac8.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/0512a2d7-cabc-4b00-b8fc-7366eb55bac8/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/0512a2d7-cabc-4b00-b8fc-7366eb55bac8/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/0512a2d7-cabc-4b00-b8fc-7366eb55bac8/diffoscope)).
